### PR TITLE
feat(release): adds the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,19 +43,45 @@ permissions:
 
 jobs:
   release:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v0.59.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@agronskiy/chore/ci/release-to-tag-with-package
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
-      python-package: nemo_eval
+      python-package: nemo_evaluator
       library-name: NeMo-Eval
       dry-run: ${{ inputs.dry-run || false }}
       version-bump-branch: ${{ inputs.version-bump-branch || github.ref_name }}
       create-gh-release: ${{ inputs.create-gh-release || true }}
+      gh-release-tag-prefix: nemo-evaluator-
       packaging: uv
       skip-test-wheel: true
       app-id: ${{ vars.BOT_ID }}
       has-src-dir: true
       root-dir: packages/nemo-evaluator
+    secrets:
+      TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+      TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+      SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_ENDPOINT }}
+      PAT: ${{ secrets.PAT }}
+      SSH_KEY: ${{ secrets.SSH_KEY }}
+      SSH_PWD: ${{ secrets.SSH_PWD }}
+      BOT_KEY: ${{ secrets.BOT_KEY }}
+
+  release-launcher:
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@agronskiy/chore/ci/release-to-tag-with-package
+    with:
+      release-ref: ${{ inputs.release-ref || github.sha }}
+      python-package: nemo_evaluator_launcher
+      library-name: NeMo-Eval
+      dry-run: ${{ inputs.dry-run || false }}
+      version-bump-branch: ${{ inputs.version-bump-branch || github.ref_name }}
+      create-gh-release: ${{ inputs.create-gh-release || true }}
+      gh-release-tag-prefix: nemo-evaluator-launcher-
+      packaging: uv
+      skip-test-wheel: true
+      app-id: ${{ vars.BOT_ID }}
+      has-src-dir: true
+      root-dir: packages/nemo-evaluator-launcher
     secrets:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,15 @@ name: "Release NeMo-Eval"
 on:
   workflow_dispatch:
     inputs:
+      component:
+        description: Component to release
+        required: true
+        default: nemo-evaluator
+        type: choice
+        options:
+          - nemo-evaluator
+          - nemo-evaluator-launcher
+          - all
       release-ref:
         description: Ref (SHA or branch name) to release
         required: true
@@ -43,6 +52,7 @@ permissions:
 
 jobs:
   release:
+    if: ${{ inputs.component == 'nemo-evaluator' || inputs.component == 'all' }}
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v0.61.0
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
@@ -68,6 +78,7 @@ jobs:
       BOT_KEY: ${{ secrets.BOT_KEY }}
 
   release-launcher:
+    if: ${{ inputs.component == 'nemo-evaluator-launcher' || inputs.component == 'all' }}
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v0.61.0
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ on:
         required: true
         type: string
       dry-run:
-        description: Do not publish a wheel and GitHub release.
+        description: "Dry Run: only publish to test PyPI"
         required: true
         default: true
         type: boolean
@@ -57,7 +57,7 @@ jobs:
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: nemo_evaluator
-      library-name: NeMo-Eval
+      library-name: NeMo Evaluator
       dry-run: ${{ inputs.dry-run || false }}
       version-bump-branch: ${{ inputs.version-bump-branch || github.ref_name }}
       create-gh-release: ${{ inputs.create-gh-release || true }}
@@ -83,7 +83,7 @@ jobs:
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: nemo_evaluator_launcher
-      library-name: NeMo-Eval
+      library-name: NeMo Evaluator Launcher
       dry-run: ${{ inputs.dry-run || false }}
       version-bump-branch: ${{ inputs.version-bump-branch || github.ref_name }}
       create-gh-release: ${{ inputs.create-gh-release || true }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,8 +43,6 @@ on:
         description: Branch for version bump
         required: true
         type: string
-  schedule:
-    - cron: "0 6 * * 1"
 
 permissions:
   contents: write # To read repository content

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ permissions:
 
 jobs:
   release:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@agronskiy/chore/ci/release-to-tag-with-package
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v0.61.0
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: nemo_evaluator
@@ -68,7 +68,7 @@ jobs:
       BOT_KEY: ${{ secrets.BOT_KEY }}
 
   release-launcher:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@agronskiy/chore/ci/release-to-tag-with-package
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v0.61.0
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: nemo_evaluator_launcher


### PR DESCRIPTION
This PR introduces the release workflow separated for `nemo-evaluator` and `nemo-evaluator-launcher`, triggered by a dropdown menu (when running manually)
<img width="454" height="543" alt="image" src="https://github.com/user-attachments/assets/f6e7829b-d249-40b1-933e-41e713519a26" />
