### PR TITLE
fix: Correctly propagate input `create-gh-release`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,7 @@ jobs:
       library-name: NeMo Evaluator
       dry-run: ${{ inputs.dry-run || false }}
       version-bump-branch: ${{ inputs.version-bump-branch || github.ref_name }}
-      create-gh-release: ${{ inputs.create-gh-release || true }}
+      create-gh-release: ${{ inputs.create-gh-release }}
       gh-release-tag-prefix: nemo-evaluator-
       packaging: uv
       skip-test-wheel: true


### PR DESCRIPTION
Since false || true always emits true, we weren't propaging the input correctly. We don't need the fallback anway since this input already has a default value.